### PR TITLE
Use logfile; fix DaemonSet example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ spec:
   template:
     metadata:
       labels:
-      app: stackdriver-agent
+        app: stackdriver-agent
     spec:
       containers:
       - name: stackdriver-agent

--- a/configurator/01-logging.sh
+++ b/configurator/01-logging.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright (C) 2016 wikiwi.io
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+
+# This file and the conf file it generates are named "01-" so
+# they are loaded as early as possible. Without this, conf files
+# that sort lexically before this one would not have logging
+# configured correctly.
+
+cat <<EOL > /opt/stackdriver/collectd/etc/collectd.d/01-logging.conf
+LoadPlugin "logfile"
+# Enable logging with logfile as syslog is not generally available inside a container.
+<Plugin "logfile">
+  LogLevel "info"
+  File "/var/log/collectd.log"
+  Timestamp true
+</Plugin>
+EOL
+


### PR DESCRIPTION
syslog is not generally available inside a container, so use Logfile to write to the expected logfile directly.

I tried using stdout instead, but it didn't work -- no logs in `kubectl logs` or in Stackdriver. I think this is because `run-agent.sh` is the container's entrypoint, not the `collectd` daemon.

The good news is run-agent.sh tails `/var/log/collectd.log`, so as-is we do see logs in kubectl logs and in Stackdriver.

This also makes a whitespace-only, documentation-only change that causes the example DaemonSet to break :).

(See also https://github.com/gpii-ops/stackdriver-agent/pull/1 though I will delete that fork soon.)